### PR TITLE
Fix Tests after downgrade to NETCoreApp2.2

### DIFF
--- a/Source/Otc.Messaging.Abstractions/IMessageContext.cs
+++ b/Source/Otc.Messaging.Abstractions/IMessageContext.cs
@@ -3,9 +3,9 @@
 namespace Otc.Messaging.Abstractions
 {
     /// <summary>
-    /// Represents a message received by a consumer.
+    /// Context metadata of a message received by a consumer.
     /// </summary>
-    public interface IMessage
+    public interface IMessageContext
     {
         /// <summary>
         /// Application generated Message Id.
@@ -32,10 +32,5 @@ namespace Otc.Messaging.Abstractions
         /// to a consumer before and was not acknowledged.
         /// </summary>
         bool Redelivered { get; }
-
-        /// <summary>
-        /// Content of the message.
-        /// </summary>
-        byte[] Body { get; }
     }
 }

--- a/Source/Otc.Messaging.Abstractions/IMessaging.cs
+++ b/Source/Otc.Messaging.Abstractions/IMessaging.cs
@@ -21,7 +21,7 @@ namespace Otc.Messaging.Abstractions
         /// <param name="queues">The list of queues to consume from.</param>
         /// <returns>Instance of <see cref="ISubscription"/> ready to start
         /// consuming messages.</returns>
-        ISubscription Subscribe(Action<IMessage> handler, params string[] queues);
+        ISubscription Subscribe(Action<byte[], IMessageContext> handler, params string[] queues);
 
         /// <summary>
         /// Ensures that a given topology is configure by the broker.

--- a/Source/Otc.Messaging.RabbitMQ.Tests/MessageHandler.cs
+++ b/Source/Otc.Messaging.RabbitMQ.Tests/MessageHandler.cs
@@ -15,16 +15,17 @@ namespace Otc.Messaging.RabbitMQ.Tests
         public int StopCount;
         public bool UseLock = false;
 
-        public void Handle(IMessage message)
+        public void Handle(byte[] message, IMessageContext messageContext)
         {
             if (!StopWatch.IsRunning)
             {
                 StopWatch.Start();
             }
 
-            var text = Encoding.UTF8.GetString(message.Body);
+            var text = Encoding.UTF8.GetString(message);
 
-            OutputHelper?.WriteLine($"{nameof(MessageHandler)}: Queue: {message.Queue} - Text: {text}");
+            OutputHelper?.WriteLine($"{nameof(MessageHandler)}: " +
+                $"Queue: {messageContext.Queue} - Text: {text}");
 
             if (UseLock)
             {

--- a/Source/Otc.Messaging.RabbitMQ.Tests/Otc.Messaging.RabbitMQ.Tests.csproj
+++ b/Source/Otc.Messaging.RabbitMQ.Tests/Otc.Messaging.RabbitMQ.Tests.csproj
@@ -13,6 +13,7 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.2.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
     <PackageReference Include="Otc.Extensions.Configuration" Version="2.0.2" />
+    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="4.7.1" />
     <PackageReference Include="xunit" Version="2.4.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
   </ItemGroup>

--- a/Source/Otc.Messaging.RabbitMQ/RabbitMQMessageContext.cs
+++ b/Source/Otc.Messaging.RabbitMQ/RabbitMQMessageContext.cs
@@ -9,14 +9,14 @@ namespace Otc.Messaging.RabbitMQ
     /// It is constructed right after a message arrives and is passed 
     /// to the registered handler. All properties are readonly.
     /// </summary>
-    public class RabbitMQMessage : IMessage
+    public class RabbitMQMessageContext : IMessageContext
     {
         /// <summary>
-        /// Creates a new <see cref="RabbitMQMessage"/>.
+        /// Creates a new <see cref="RabbitMQMessageContext"/>.
         /// </summary>
         /// <param name="ea">Message's metadata sent by the broker.</param>
         /// <param name="queue">The queue it came from.</param>
-        public RabbitMQMessage(BasicDeliverEventArgs ea, string queue)
+        public RabbitMQMessageContext(BasicDeliverEventArgs ea, string queue)
         {
             Id = ea.BasicProperties.MessageId;
             Timestamp = DateTimeOffset
@@ -24,7 +24,6 @@ namespace Otc.Messaging.RabbitMQ
             Topic = ea.Exchange;
             Queue = queue;
             Redelivered = ea.Redelivered;
-            Body = ea.Body.ToArray();
         }
 
         /// <inheritdoc/>
@@ -41,8 +40,5 @@ namespace Otc.Messaging.RabbitMQ
 
         /// <inheritdoc/>
         public bool Redelivered { get; }
-
-        /// <inheritdoc/>
-        public byte[] Body { get; }
     }
 }

--- a/Source/Otc.Messaging.RabbitMQ/RabbitMQMessaging.cs
+++ b/Source/Otc.Messaging.RabbitMQ/RabbitMQMessaging.cs
@@ -105,7 +105,7 @@ namespace Otc.Messaging.RabbitMQ
         /// <returns>Instance of <see cref="RabbitMQSubscription"/> ready to start
         /// consuming messages.</returns>
         /// <inheritdoc/>
-        public ISubscription Subscribe(Action<IMessage> handler, params string[] queues)
+        public ISubscription Subscribe(Action<byte[], IMessageContext> handler, params string[] queues)
         {
             if (disposed)
             {


### PR DESCRIPTION
Added missing dependency after downgrade to netcoreapp2.2
Introducing MessageContext to segregate message content from its metadata (preparing for Typed Messages)