### PR TITLE
Overall resilience improvements.

### DIFF
--- a/Source/Otc.Messaging.Abstractions/Otc.Messaging.Abstractions.csproj
+++ b/Source/Otc.Messaging.Abstractions/Otc.Messaging.Abstractions.csproj
@@ -5,7 +5,7 @@
     <Authors>Ole Consignado</Authors>
     <Copyright>Ole Consignado (c) 2020</Copyright>
     <VersionPrefix>1.0.0</VersionPrefix>
-    <PackageProjectUrl>https://github.com/OleConsignado/otc-messaging/</PackageProjectUrl>  
+    <PackageProjectUrl>https://github.com/OleConsignado/otc-messaging/</PackageProjectUrl>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/Source/Otc.Messaging.RabbitMQ.Tests/appsettings.json
+++ b/Source/Otc.Messaging.RabbitMQ.Tests/appsettings.json
@@ -4,7 +4,6 @@
     "Port": 5672,
     "User": "guest",
     "Password": "guest",
-    "PublishConfirmationTimeout": 15000,
     "PerQueuePrefetchCount": 10,
     "MessageHandlerErrorBehavior": 0,
     "Topologies": {

--- a/Source/Otc.Messaging.RabbitMQ/Configurations/RabbitMQConfiguration.cs
+++ b/Source/Otc.Messaging.RabbitMQ/Configurations/RabbitMQConfiguration.cs
@@ -42,6 +42,11 @@ namespace Otc.Messaging.RabbitMQ.Configurations
         public string Password { set; get; }
 
         /// <summary>
+        /// Client provided name to be used for connection identification.
+        /// </summary>
+        public string ClientProvidedName { get; set; } = $"otc-messaging";
+
+        /// <summary>
         /// Timeout in milliseconds. Throws an exception if confirmation wait time is exceded or
         /// if broker sends back an nack. Default is 15 seconds.
         /// </summary>

--- a/Source/Otc.Messaging.RabbitMQ/Otc.Messaging.RabbitMQ.csproj
+++ b/Source/Otc.Messaging.RabbitMQ/Otc.Messaging.RabbitMQ.csproj
@@ -5,7 +5,7 @@
     <Authors>Ole Consignado</Authors>
     <Copyright>Ole Consignado (c) 2020</Copyright>
     <VersionPrefix>1.0.0</VersionPrefix>
-    <PackageProjectUrl>https://github.com/OleConsignado/otc-messaging/</PackageProjectUrl>      
+    <PackageProjectUrl>https://github.com/OleConsignado/otc-messaging/</PackageProjectUrl>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
@@ -24,7 +24,6 @@
     <PackageReference Include="RabbitMQ.Client" Version="6.0.0" />
     <PackageReference Include="Otc.ComponentModel.Annotations" Version="1.0.1" />
   </ItemGroup>
-
 
   <ItemGroup>
     <ProjectReference Include="..\Otc.Messaging.Abstractions\Otc.Messaging.Abstractions.csproj" />


### PR DESCRIPTION
* Connection now handles concurrent initialization.
* Subscriptions won't crash on channel outage while waiting for built in Auto Recovery takes place.
* Subscriptions auto recovery will not timeout but will keep emiting errors (each 1 minute) in case of a channel outage so that Operations Team take notice and fix the problem.
* It's now possible to set up a connection name in configuration so that it appears on Management UI.
* Minor fixes.