### PR TITLE
Implementing Otc.Messaging.RabbitMQ.Cli

### DIFF
--- a/Source/Otc.Messaging.RabbitMQ.Cli/Broker.cs
+++ b/Source/Otc.Messaging.RabbitMQ.Cli/Broker.cs
@@ -1,0 +1,57 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+using Otc.Messaging.Abstractions;
+using Otc.Messaging.RabbitMQ.Configurations;
+using System;
+using System.Collections.Generic;
+
+namespace Otc.Messaging.RabbitMQ.Cli
+{
+    public static class Broker
+    {
+        public static string Host { get; set; }
+        public static int Port { get; set; }
+        public static string User { get; set; }
+        public static string Password { get; set; }
+        public static string VirtualHost { get; set; }
+        public static int ApiPort { get; set; } = 15672;
+        public static string ApiBaseUrl
+        {
+            get => $"http://{Host}:{ApiPort}/api";
+        }
+
+        private static RabbitMQConfiguration configuration;
+        public static RabbitMQConfiguration Configuration
+        {
+            get
+            {
+                if (configuration == null)
+                {
+                    configuration = new RabbitMQConfiguration
+                    {
+                        Hosts = new List<string> { Host },
+                        Port = Port,
+                        User = User,
+                        Password = Password,
+                        VirtualHost = VirtualHost
+                    };
+                }
+
+                return configuration;
+            }
+
+            set => configuration = value;
+        }
+
+        private static IMessaging broker;
+        public static IMessaging GetInstance()
+        {
+            if (broker == null)
+            {
+                var provider = ServiceProvider.GetInstance();
+                broker = provider.GetService<IMessaging>();
+            }
+
+            return broker;
+        }
+    }
+}

--- a/Source/Otc.Messaging.RabbitMQ.Cli/Commands/ApplyMirrorPolicy.cs
+++ b/Source/Otc.Messaging.RabbitMQ.Cli/Commands/ApplyMirrorPolicy.cs
@@ -1,0 +1,145 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+using Newtonsoft.Json.Linq;
+using Otc.Messaging.RabbitMQ.Cli.Exceptions;
+using System;
+using System.CommandLine;
+using System.CommandLine.Invocation;
+using System.Linq;
+using System.Net;
+using System.Threading.Tasks;
+
+namespace Otc.Messaging.RabbitMQ.Cli.Commands
+{
+    public static class ApplyMirrorPolicy
+    {
+        private static readonly string DefaultErrorMessage = "Error applying mirror policy. ";
+
+        public static Command Setup()
+        {
+            var cmd = new Command(nameof(ApplyMirrorPolicy));
+
+            var option = new Option<string>(new[] { "--name", "-n" });
+            option.Argument.Arity = ArgumentArity.ExactlyOne;
+            option.Description = "Name of Policy to be created.";
+            cmd.AddOption(option);
+
+            option = new Option<string>(new[] { "--pattern" }, () => ".*");
+            option.Argument.Arity = ArgumentArity.ZeroOrOne;
+            option.Description = "Pattern matching queues names.";
+            cmd.AddOption(option);
+
+            cmd.Handler = CommandHandler.Create<string, string>(Execute);
+
+            return cmd;
+        }
+
+        public static async Task Execute(string name, string pattern)
+        {
+            try
+            {
+                Console.WriteLine("Executing...");
+
+                if (string.IsNullOrEmpty(name))
+                {
+                    throw new ArgumentException($"Option --{nameof(name)} is required.");
+                }
+
+                if (string.IsNullOrEmpty(pattern))
+                {
+                    throw new ArgumentException($"Option --{nameof(pattern)} is required.");
+                }
+
+                var provider = ServiceProvider.GetInstance();
+                var api = provider.GetService<IRabbitMQApi>();
+
+                var body = await PrepareBody(api, pattern);
+                var response = await api.PutPolicy(Broker.VirtualHost, name, body);
+                if (!response.IsSuccessStatusCode)
+                {
+                    if (response.StatusCode == HttpStatusCode.NotFound)
+                    {
+                        throw new CliException(DefaultErrorMessage +
+                            $"VirtualHost {Broker.VirtualHost} not found.");
+                    }
+
+                    throw new CliException(DefaultErrorMessage +
+                        $"{ response.StatusCode } - { response.ReasonPhrase}.");
+                }
+
+                Console.WriteLine($"Mirror policy {name} applied successfully to queues matching ({pattern})!");
+            }
+            catch (Exception e)
+            {
+                ExceptionHandler.Handle(e);
+            }
+        }
+
+        private static async Task<string> PrepareBody(IRabbitMQApi api, string pattern)
+        {
+            var nodes = await FetchNumberOfNodes(api);
+            var mirrors = CalculateNumberOfMirrors(nodes);
+            return BuildPayload(mirrors, pattern);
+        }
+
+        private static async Task<int> FetchNumberOfNodes(IRabbitMQApi api)
+        {
+            var response = await api.GetOverview();
+            if (!response.IsSuccessStatusCode)
+            {
+                throw new CliException(DefaultErrorMessage +
+                    $"{ response.StatusCode } - { response.ReasonPhrase}.");
+            }
+
+            JObject json = JObject.Parse(response.Content);
+            var nodes = json.SelectTokens("$.listeners[?(@.protocol == 'amqp')]");
+
+            var numberOfNodes = nodes?.Count();
+
+            if (numberOfNodes == null)
+            {
+                throw new CliException(DefaultErrorMessage + 
+                    "Could not fetch number of nodes in this cluster.");
+            }
+
+            if (numberOfNodes == 0)
+            {
+                throw new CliException(DefaultErrorMessage +
+                    "No node is listening to amqp comunication in this cluster.");
+            }
+
+            return numberOfNodes.Value;
+        }
+
+        /// <summary>
+        /// Calculates the recommended number of mirrors for a queue, based on 
+        /// https://www.rabbitmq.com/ha.html#replication-factor.
+        /// </summary>
+        /// <param name="nodes">Actual number of nodes in the cluster</param>
+        /// <returns>Number of mirrors to be used.</returns>
+        private static int CalculateNumberOfMirrors(int nodes)
+        {
+            return (nodes > 3)
+                ? nodes / 2 + 1
+                : nodes;
+        }
+
+        private static string BuildPayload(int numberOfMirrors, string pattern)
+        {
+            var body = $@"
+            {{
+                ""pattern"":""{pattern}"",
+                ""apply-to"":""queues"",
+                ""priority"":0,
+                ""definition"":{{
+                    ""ha-mode"":""exactly"",
+                    ""ha-params"":{numberOfMirrors},
+                    ""ha-promote-on-failure"":""when-synced"",
+                    ""ha-promote-on-shutdown"":""when-synced"",
+                    ""ha-sync-mode"":""automatic""
+                }}
+            }}";
+
+            return body;
+        }
+    }
+}

--- a/Source/Otc.Messaging.RabbitMQ.Cli/Commands/ApplyMirrorPolicy.cs
+++ b/Source/Otc.Messaging.RabbitMQ.Cli/Commands/ApplyMirrorPolicy.cs
@@ -28,12 +28,12 @@ namespace Otc.Messaging.RabbitMQ.Cli.Commands
             option.Description = "Pattern matching queues names.";
             cmd.AddOption(option);
 
-            cmd.Handler = CommandHandler.Create<string, string>(Execute);
+            cmd.Handler = CommandHandler.Create<string, string>(ExecuteAsync);
 
             return cmd;
         }
 
-        public static async Task Execute(string name, string pattern)
+        public static async Task ExecuteAsync(string name, string pattern)
         {
             try
             {
@@ -52,8 +52,8 @@ namespace Otc.Messaging.RabbitMQ.Cli.Commands
                 var provider = ServiceProvider.GetInstance();
                 var api = provider.GetService<IRabbitMQApi>();
 
-                var body = await PrepareBody(api, pattern);
-                var response = await api.PutPolicy(Broker.VirtualHost, name, body);
+                var body = await PrepareBodyAsync(api, pattern);
+                var response = await api.PutPolicyAsync(Broker.VirtualHost, name, body);
                 if (!response.IsSuccessStatusCode)
                 {
                     if (response.StatusCode == HttpStatusCode.NotFound)
@@ -74,16 +74,16 @@ namespace Otc.Messaging.RabbitMQ.Cli.Commands
             }
         }
 
-        private static async Task<string> PrepareBody(IRabbitMQApi api, string pattern)
+        private static async Task<string> PrepareBodyAsync(IRabbitMQApi api, string pattern)
         {
-            var nodes = await FetchNumberOfNodes(api);
+            var nodes = await FetchNumberOfNodesAsync(api);
             var mirrors = CalculateNumberOfMirrors(nodes);
             return BuildPayload(mirrors, pattern);
         }
 
-        private static async Task<int> FetchNumberOfNodes(IRabbitMQApi api)
+        private static async Task<int> FetchNumberOfNodesAsync(IRabbitMQApi api)
         {
-            var response = await api.GetOverview();
+            var response = await api.GetOverviewAsync();
             if (!response.IsSuccessStatusCode)
             {
                 throw new CliException(DefaultErrorMessage +

--- a/Source/Otc.Messaging.RabbitMQ.Cli/Commands/CreateMultipleQueues.cs
+++ b/Source/Otc.Messaging.RabbitMQ.Cli/Commands/CreateMultipleQueues.cs
@@ -1,0 +1,50 @@
+﻿using Otc.Messaging.RabbitMQ.Cli.Options;
+using Otc.Messaging.RabbitMQ.PredefinedTopologies;
+using System;
+using System.Collections.Generic;
+using System.CommandLine;
+using System.CommandLine.Invocation;
+
+namespace Otc.Messaging.RabbitMQ.Cli.Commands
+{
+    public static class CreateMultipleQueues
+    {
+        public static Command Setup()
+        {
+            var cmd = new Command(nameof(CreateMultipleQueues));
+
+            TopicOption.AddIn(cmd);
+            QueuesOption.AddIn(cmd);
+            RetriesOption.AddIn(cmd);
+            cmd.Handler = CommandHandler.Create<string, string[], string[]>(Execute);
+
+            return cmd;
+        }
+
+        public static void Execute(string topic, string[] queues, string[] retries)
+        {
+            try
+            {
+                Console.WriteLine("Executing...");
+
+                var args = new List<object>();
+                TopicOption.Validate(topic);
+                QueuesOption.Validate(queues, args);
+                RetriesOption.Validate(retries, args);
+
+                Broker.Configuration
+                    .AddTopology<MultipleQueuesWithRetryTopologyFactory>(
+                        topic, args.ToArray());
+
+                var broker = Broker.GetInstance();
+                broker.EnsureTopology(topic);
+
+                Console.WriteLine($"Topic {topic} with multiple queues created successfully!");
+            }
+            catch (Exception e)
+            {
+                ExceptionHandler.Handle(e);
+            }
+        }
+    }
+}

--- a/Source/Otc.Messaging.RabbitMQ.Cli/Commands/CreateSimpleQueue.cs
+++ b/Source/Otc.Messaging.RabbitMQ.Cli/Commands/CreateSimpleQueue.cs
@@ -1,0 +1,48 @@
+﻿using Otc.Messaging.RabbitMQ.Cli.Options;
+using Otc.Messaging.RabbitMQ.PredefinedTopologies;
+using System;
+using System.Collections.Generic;
+using System.CommandLine;
+using System.CommandLine.Invocation;
+
+namespace Otc.Messaging.RabbitMQ.Cli.Commands
+{
+    public static class CreateSimpleQueue
+    {
+        public static Command Setup()
+        {
+            var cmd = new Command(nameof(CreateSimpleQueue));
+
+            TopicOption.AddIn(cmd);
+            RetriesOption.AddIn(cmd);
+            cmd.Handler = CommandHandler.Create<string, string[]>(Execute);
+
+            return cmd;
+        }
+
+        public static void Execute(string topic, string[] retries)
+        {
+            try
+            {
+                Console.WriteLine("Executing...");
+
+                var args = new List<object>();
+                TopicOption.Validate(topic);
+                RetriesOption.Validate(retries, args);
+
+                Broker.Configuration
+                    .AddTopology<SimpleQueueWithRetryTopologyFactory>(
+                        topic, args.ToArray());
+
+                var broker = Broker.GetInstance();
+                broker.EnsureTopology(topic);
+
+                Console.WriteLine($"Simple queue {topic} created successfully!");
+            }
+            catch (Exception e)
+            {
+                ExceptionHandler.Handle(e);
+            }
+        }
+    }
+}

--- a/Source/Otc.Messaging.RabbitMQ.Cli/Commands/CreateVirtualHost.cs
+++ b/Source/Otc.Messaging.RabbitMQ.Cli/Commands/CreateVirtualHost.cs
@@ -16,12 +16,12 @@ namespace Otc.Messaging.RabbitMQ.Cli.Commands
         {
             var cmd = new Command(nameof(CreateVirtualHost));
 
-            cmd.Handler = CommandHandler.Create(Execute);
+            cmd.Handler = CommandHandler.Create(ExecuteAsync);
 
             return cmd;
         }
 
-        public static async Task Execute()
+        public static async Task ExecuteAsync()
         {
             try
             {
@@ -31,7 +31,7 @@ namespace Otc.Messaging.RabbitMQ.Cli.Commands
                 var provider = ServiceProvider.GetInstance();
                 var api = provider.GetService<IRabbitMQApi>();
 
-                var response = await api.GetVHost(name);
+                var response = await api.GetVHostAsync(name);
                 if (response.StatusCode == HttpStatusCode.OK)
                 {
                     throw new CliException(
@@ -44,7 +44,7 @@ namespace Otc.Messaging.RabbitMQ.Cli.Commands
                         $"{response.StatusCode} - {response.ReasonPhrase}.");
                 }
 
-                response = await api.PutVHost(name);
+                response = await api.PutVHostAsync(name);
                 if (response.StatusCode != HttpStatusCode.Created)
                 {
                     throw new CliException(DefaultErrorMessage +
@@ -54,7 +54,7 @@ namespace Otc.Messaging.RabbitMQ.Cli.Commands
                 Console.WriteLine($"VirtualHost {name} created successfully!");
 
                 Console.WriteLine($"Applying default mirror policy");
-                await ApplyMirrorPolicy.Execute("default-mirror-policy", ".*");
+                await ApplyMirrorPolicy.ExecuteAsync("default-mirror-policy", ".*");
             }
             catch (Exception e)
             {

--- a/Source/Otc.Messaging.RabbitMQ.Cli/Commands/CreateVirtualHost.cs
+++ b/Source/Otc.Messaging.RabbitMQ.Cli/Commands/CreateVirtualHost.cs
@@ -1,0 +1,63 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+using System;
+using System.CommandLine;
+using System.CommandLine.Invocation;
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+
+namespace Otc.Messaging.RabbitMQ.Cli.Commands
+{
+    public static class CreateVirtualHost
+    {
+        public static Command Setup()
+        {
+            var cmd = new Command(nameof(CreateVirtualHost));
+
+            var option = new Option<string>(new[] { "--name", "-n" });
+            option.Argument.Arity = ArgumentArity.ExactlyOne;
+            option.Description = "Name of VirtualHost to be created.";
+            cmd.AddOption(option);
+            cmd.Handler = CommandHandler.Create<string>(Execute);
+
+            return cmd;
+        }
+
+        public static async Task Execute(string name)
+        {
+            try
+            {
+                Console.WriteLine("Executing...");
+
+                var provider = ServiceProvider.GetInstance();
+                var api = provider.GetService<IRabbitMQApi>();
+
+                var response = await api.GetVHost(name);
+                if (response.StatusCode == HttpStatusCode.OK)
+                {
+                    throw new InvalidOperationException(
+                        $"VirtualHost {name} already exists.");
+                }
+
+                if (response.StatusCode != HttpStatusCode.NotFound)
+                {
+                    throw new HttpRequestException($"Response status not expected: " +
+                        $"{response.StatusCode} - {response.ReasonPhrase}.");
+                }
+
+                response = await api.PutVHost(name);
+                if (response.StatusCode != HttpStatusCode.Created)
+                {
+                    throw new HttpRequestException($"Response status not expected: " +
+                        $"{response.StatusCode} - {response.ReasonPhrase}.");
+                }
+
+                Console.WriteLine($"VirtualHost {name} created!");
+            }
+            catch (Exception e)
+            {
+                ExceptionHandler.Handle(e);
+            }
+        }
+    }
+}

--- a/Source/Otc.Messaging.RabbitMQ.Cli/Commands/CreateVirtualHost.cs
+++ b/Source/Otc.Messaging.RabbitMQ.Cli/Commands/CreateVirtualHost.cs
@@ -1,58 +1,60 @@
 ﻿using Microsoft.Extensions.DependencyInjection;
+using Otc.Messaging.RabbitMQ.Cli.Exceptions;
 using System;
 using System.CommandLine;
 using System.CommandLine.Invocation;
 using System.Net;
-using System.Net.Http;
 using System.Threading.Tasks;
 
 namespace Otc.Messaging.RabbitMQ.Cli.Commands
 {
     public static class CreateVirtualHost
     {
+        private static readonly string DefaultErrorMessage = "Error creating virtual host. ";
+
         public static Command Setup()
         {
             var cmd = new Command(nameof(CreateVirtualHost));
 
-            var option = new Option<string>(new[] { "--name", "-n" });
-            option.Argument.Arity = ArgumentArity.ExactlyOne;
-            option.Description = "Name of VirtualHost to be created.";
-            cmd.AddOption(option);
-            cmd.Handler = CommandHandler.Create<string>(Execute);
+            cmd.Handler = CommandHandler.Create(Execute);
 
             return cmd;
         }
 
-        public static async Task Execute(string name)
+        public static async Task Execute()
         {
             try
             {
                 Console.WriteLine("Executing...");
 
+                var name = Broker.VirtualHost;
                 var provider = ServiceProvider.GetInstance();
                 var api = provider.GetService<IRabbitMQApi>();
 
                 var response = await api.GetVHost(name);
                 if (response.StatusCode == HttpStatusCode.OK)
                 {
-                    throw new InvalidOperationException(
+                    throw new CliException(
                         $"VirtualHost {name} already exists.");
                 }
 
                 if (response.StatusCode != HttpStatusCode.NotFound)
                 {
-                    throw new HttpRequestException($"Response status not expected: " +
+                    throw new CliException(DefaultErrorMessage +
                         $"{response.StatusCode} - {response.ReasonPhrase}.");
                 }
 
                 response = await api.PutVHost(name);
                 if (response.StatusCode != HttpStatusCode.Created)
                 {
-                    throw new HttpRequestException($"Response status not expected: " +
+                    throw new CliException(DefaultErrorMessage +
                         $"{response.StatusCode} - {response.ReasonPhrase}.");
                 }
 
-                Console.WriteLine($"VirtualHost {name} created!");
+                Console.WriteLine($"VirtualHost {name} created successfully!");
+
+                Console.WriteLine($"Applying default mirror policy");
+                await ApplyMirrorPolicy.Execute("default-mirror-policy", ".*");
             }
             catch (Exception e)
             {

--- a/Source/Otc.Messaging.RabbitMQ.Cli/ExceptionHandler.cs
+++ b/Source/Otc.Messaging.RabbitMQ.Cli/ExceptionHandler.cs
@@ -1,0 +1,22 @@
+﻿using System;
+
+namespace Otc.Messaging.RabbitMQ.Cli
+{
+    public static class ExceptionHandler
+    {
+        public static void Handle(Exception e)
+        {
+            Report(e);
+            Environment.Exit(1);
+        }
+
+        private static void Report(Exception e)
+        {
+            Console.WriteLine(e.GetType().Name + ": " + e.Message);
+            if (e.InnerException != null)
+            {
+                Report(e.InnerException);
+            }
+        }
+    }
+}

--- a/Source/Otc.Messaging.RabbitMQ.Cli/Exceptions/CliException.cs
+++ b/Source/Otc.Messaging.RabbitMQ.Cli/Exceptions/CliException.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Runtime.Serialization;
+
+namespace Otc.Messaging.RabbitMQ.Cli.Exceptions
+{
+    [Serializable]
+    public class CliException : Exception
+    {
+        public CliException(string message)
+            : base(message)
+        {
+        }
+
+        protected CliException(SerializationInfo info, StreamingContext context)
+            : base(info, context)
+        {
+        }
+    }
+}

--- a/Source/Otc.Messaging.RabbitMQ.Cli/IRabbitMQApi.cs
+++ b/Source/Otc.Messaging.RabbitMQ.Cli/IRabbitMQApi.cs
@@ -6,15 +6,15 @@ namespace Otc.Messaging.RabbitMQ.Cli
     internal interface IRabbitMQApi
     {
         [Get("/overview")]
-        Task<ApiResponse<string>> GetOverview();
+        Task<ApiResponse<string>> GetOverviewAsync();
 
         [Get("/vhosts/{name}")]
-        Task<ApiResponse<string>> GetVHost(string name);
+        Task<ApiResponse<string>> GetVHostAsync(string name);
 
         [Put("/vhosts/{name}")]
-        Task<ApiResponse<string>> PutVHost(string name);
+        Task<ApiResponse<string>> PutVHostAsync(string name);
 
         [Put("/policies/{vhost}/{name}")]
-        Task<ApiResponse<string>> PutPolicy(string vhost, string name, [Body] string body);
+        Task<ApiResponse<string>> PutPolicyAsync(string vhost, string name, [Body] string body);
     }
 }

--- a/Source/Otc.Messaging.RabbitMQ.Cli/IRabbitMQApi.cs
+++ b/Source/Otc.Messaging.RabbitMQ.Cli/IRabbitMQApi.cs
@@ -5,10 +5,16 @@ namespace Otc.Messaging.RabbitMQ.Cli
 {
     internal interface IRabbitMQApi
     {
+        [Get("/overview")]
+        Task<ApiResponse<string>> GetOverview();
+
         [Get("/vhosts/{name}")]
         Task<ApiResponse<string>> GetVHost(string name);
 
         [Put("/vhosts/{name}")]
         Task<ApiResponse<string>> PutVHost(string name);
+
+        [Put("/policies/{vhost}/{name}")]
+        Task<ApiResponse<string>> PutPolicy(string vhost, string name, [Body] string body);
     }
 }

--- a/Source/Otc.Messaging.RabbitMQ.Cli/IRabbitMQApi.cs
+++ b/Source/Otc.Messaging.RabbitMQ.Cli/IRabbitMQApi.cs
@@ -1,0 +1,14 @@
+﻿using Refit;
+using System.Threading.Tasks;
+
+namespace Otc.Messaging.RabbitMQ.Cli
+{
+    internal interface IRabbitMQApi
+    {
+        [Get("/vhosts/{name}")]
+        Task<ApiResponse<string>> GetVHost(string name);
+
+        [Put("/vhosts/{name}")]
+        Task<ApiResponse<string>> PutVHost(string name);
+    }
+}

--- a/Source/Otc.Messaging.RabbitMQ.Cli/Options/QueuesOption.cs
+++ b/Source/Otc.Messaging.RabbitMQ.Cli/Options/QueuesOption.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Collections.Generic;
+using System.CommandLine;
+using System.Linq;
+
+namespace Otc.Messaging.RabbitMQ.Cli.Options
+{
+    public static class QueuesOption
+    {
+        public static void AddIn(Command cmd)
+        {
+            var option = new Option<string>(new[] { "--queues", "-q" });
+            option.Argument.Arity = ArgumentArity.OneOrMore;
+            option.Description = "Queues names.";
+            cmd.AddOption(option);
+        }
+
+        public static void Validate(string[] queues, List<object> args)
+        {
+            if (queues == null)
+            {
+                throw new ArgumentException($"Option --{nameof(queues)} is required.");
+            }
+
+            args.AddRange(queues.AsEnumerable());
+        }
+    }
+}

--- a/Source/Otc.Messaging.RabbitMQ.Cli/Options/RetriesOption.cs
+++ b/Source/Otc.Messaging.RabbitMQ.Cli/Options/RetriesOption.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Collections.Generic;
+using System.CommandLine;
+using System.Linq;
+
+namespace Otc.Messaging.RabbitMQ.Cli.Options
+{
+    public static class RetriesOption
+    {
+        public static void AddIn(Command cmd)
+        {
+            var option = new Option<string>(new[] { "--retries", "-r" });
+            option.Argument.Arity = ArgumentArity.ZeroOrMore;
+            option.Description = "Retry wait in milliseconds.";
+            cmd.AddOption(option);
+        }
+
+        public static void Validate(string[] retries, List<object> args)
+        {
+            if (retries != null)
+            {
+                args.AddRange(retries.AsEnumerable().Select(i =>
+                {
+                    if (!int.TryParse(i, out int retry))
+                    {
+                        throw new InvalidCastException($"Value {i} is not an integer.");
+                    }
+                    return (object)retry;
+                }));
+            }
+        }
+    }
+}

--- a/Source/Otc.Messaging.RabbitMQ.Cli/Options/TopicOption.cs
+++ b/Source/Otc.Messaging.RabbitMQ.Cli/Options/TopicOption.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.CommandLine;
+
+namespace Otc.Messaging.RabbitMQ.Cli.Options
+{
+    public static class TopicOption
+    {
+        public static void AddIn(Command cmd)
+        {
+            var option = new Option<string>(new[] { "--topic", "-t" });
+            option.Argument.Arity = ArgumentArity.ExactlyOne;
+            option.Description = "Main topic name.";
+            cmd.AddOption(option);
+        }
+
+        public static void Validate(string topic)
+        {
+            if (string.IsNullOrEmpty(topic))
+            {
+                throw new ArgumentException($"Option --{nameof(topic)} is required.");
+            }
+        }
+    }
+}

--- a/Source/Otc.Messaging.RabbitMQ.Cli/Otc.Messaging.RabbitMQ.Cli.csproj
+++ b/Source/Otc.Messaging.RabbitMQ.Cli/Otc.Messaging.RabbitMQ.Cli.csproj
@@ -8,7 +8,6 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.9" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="3.1.9" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.9" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="3.1.9" />
     <PackageReference Include="Refit" Version="5.2.1" />

--- a/Source/Otc.Messaging.RabbitMQ.Cli/Otc.Messaging.RabbitMQ.Cli.csproj
+++ b/Source/Otc.Messaging.RabbitMQ.Cli/Otc.Messaging.RabbitMQ.Cli.csproj
@@ -1,0 +1,23 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <AssemblyName>otcrabbitmq</AssemblyName>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.9" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="3.1.9" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="3.1.9" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="3.1.9" />
+    <PackageReference Include="Refit" Version="5.2.1" />
+    <PackageReference Include="Refit.HttpClientFactory" Version="5.2.1" />
+    <PackageReference Include="System.CommandLine" Version="2.0.0-beta1.20371.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Otc.Messaging.RabbitMQ.PredefinedTopologies\Otc.Messaging.RabbitMQ.PredefinedTopologies.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Source/Otc.Messaging.RabbitMQ.Cli/Program.cs
+++ b/Source/Otc.Messaging.RabbitMQ.Cli/Program.cs
@@ -1,0 +1,56 @@
+﻿using Otc.Messaging.RabbitMQ.Cli.Commands;
+using System.CommandLine;
+using System.Threading.Tasks;
+
+namespace Otc.Messaging.RabbitMQ.Cli
+{
+    static class Program
+    {
+        static async Task Main(string[] args)
+        {
+            var cli = new RootCommand("Otc.Messaging.RabbitMQ.Cli");
+
+            SetupGlobalOptions(cli);
+
+            // Setup available commands
+            cli.AddCommand(CreateSimpleQueue.Setup());
+            cli.AddCommand(CreateMultipleQueues.Setup());
+            cli.AddCommand(CreateVirtualHost.Setup());
+
+            // Parse command line arguments
+            var parsed = cli.Parse(args);
+
+            // Sets global options
+            Broker.Host = parsed.CommandResult.ValueForOption<string>("--host");
+            Broker.Port = parsed.CommandResult.ValueForOption<int>("--port");
+            Broker.ApiPort = parsed.CommandResult.ValueForOption<int>("--apiport");
+            Broker.User = parsed.CommandResult.ValueForOption<string>("--user");
+            Broker.Password = parsed.CommandResult.ValueForOption<string>("--pass");
+            Broker.VirtualHost = parsed.CommandResult.ValueForOption<string>("--vhost");
+
+            // Invoke execution
+            await cli.InvokeAsync(args);
+        }
+
+        static void SetupGlobalOptions(RootCommand cli)
+        {
+            cli.AddZeroOrOneOption(new Option<string>(
+                new[] { "--host", "-h" }, () => "localhost"));
+
+            cli.AddZeroOrOneOption(new Option<int>(
+                new[] { "--port", "-p" }, () => -1));
+
+            cli.AddZeroOrOneOption(new Option<int>(
+                new[] { "--apiport", "-a" }, () => Broker.ApiPort));
+
+            cli.AddZeroOrOneOption(new Option<string>(
+                new[] { "--user", "-u" }, () => "guest"));
+
+            cli.AddZeroOrOneOption(new Option<string>(
+                new[] { "--pass", "-s" }, () => "guest"));
+
+            cli.AddZeroOrOneOption(new Option<string>(
+                new[] { "--vhost", "-v" }, () => "/"));
+        }
+    }
+}

--- a/Source/Otc.Messaging.RabbitMQ.Cli/Program.cs
+++ b/Source/Otc.Messaging.RabbitMQ.Cli/Program.cs
@@ -16,6 +16,7 @@ namespace Otc.Messaging.RabbitMQ.Cli
             cli.AddCommand(CreateSimpleQueue.Setup());
             cli.AddCommand(CreateMultipleQueues.Setup());
             cli.AddCommand(CreateVirtualHost.Setup());
+            cli.AddCommand(ApplyMirrorPolicy.Setup());
 
             // Parse command line arguments
             var parsed = cli.Parse(args);

--- a/Source/Otc.Messaging.RabbitMQ.Cli/README.md
+++ b/Source/Otc.Messaging.RabbitMQ.Cli/README.md
@@ -16,7 +16,7 @@ Run `otcrabbitmq -h` to get a list of global arguments needed to connect to your
 
 ### Creating a new virtual host named cli-tests.
 
-`./otcrabbitmq CreateVirtualHost -n cli-tests`
+`./otcrabbitmq CreateVirtualHost -v cli-tests`
 
 ### Creating a simple queue topology in a virtual host.
 
@@ -29,3 +29,9 @@ Run `otcrabbitmq -h` to get a list of global arguments needed to connect to your
 ### Creating a fanout queue topology with 2 queues and 2 retries each.
 
 `./otcrabbitmq CreateMultipleQueues -v cli-tests -t my-topic-with-2-queues-and-2-retries-each -q my-queue-1 my-queue-2 -r 10000 20000`
+
+### Applying mirror policy to all queues starting with 'my-queue'.
+
+`./otcrabbitmq ApplyMirrorPolicy -v cli-tests -n my-policy --pattern "^my-queue.*"`
+
+*Note:* All VirtualHosts are created with a default mirror policy that applies to all of its queues.

--- a/Source/Otc.Messaging.RabbitMQ.Cli/README.md
+++ b/Source/Otc.Messaging.RabbitMQ.Cli/README.md
@@ -1,8 +1,8 @@
 # Otc.Messaging.RabbitMQ.Cli
 
-This is a simple commandline utility allowing to apply predefined topologies found in [Otc.Messaging.RabbitMQ.PredefinedTopologies](https://github.com/OleConsignado/otc-messaging/tree/master/Source/Otc.Messaging.RabbitMQ.PredefinedTopologies).
+This is a simple commandline utility allowing to apply predefined topologies found in [Otc.Messaging.RabbitMQ.PredefinedTopologies](../Otc.Messaging.RabbitMQ.PredefinedTopologies).
 
-It may grow to acomodate more commands as need appears, check [this link](https://github.com/OleConsignado/otc-messaging/tree/master/Source/Otc.Messaging.RabbitMQ.Cli/Commands) to get a list of available commands.
+It may grow to acomodate more commands as need appears, check [here](./Commands) to get a list of available commands.
 
 ## Compiling
 

--- a/Source/Otc.Messaging.RabbitMQ.Cli/README.md
+++ b/Source/Otc.Messaging.RabbitMQ.Cli/README.md
@@ -1,0 +1,31 @@
+# Otc.Messaging.RabbitMQ.Cli
+
+This is a simple commandline utility allowing to apply predefined topologies found in [Otc.Messaging.RabbitMQ.PredefinedTopologies](https://github.com/OleConsignado/otc-messaging/tree/master/Source/Otc.Messaging.RabbitMQ.PredefinedTopologies).
+
+It may grow to acomodate more commands as need appears, check [this link](https://github.com/OleConsignado/otc-messaging/tree/master/Source/Otc.Messaging.RabbitMQ.Cli/Commands) to get a list of available commands.
+
+## Compiling
+
+Compile using dotnet cli. Here is an example of linux publishing:
+
+`dotnet publish -r linux-x64 -p:PublishSingleFile=true --self-contained true -o ./linux-x64`
+
+## Basic Usage
+
+Run `otcrabbitmq -h` to get a list of global arguments needed to connect to your RabbitMQ installation, like host, port, user and password.
+
+### Creating a new virtual host named cli-tests.
+
+`./otcrabbitmq CreateVirtualHost -n cli-tests`
+
+### Creating a simple queue topology in a virtual host.
+
+`./otcrabbitmq CreateSimpleQueue -v cli-tests -t my-simple-queue`
+
+### Creating a simple queue topology with 2 retries, one after 10 seconds, and another after 20 seconds.
+
+`./otcrabbitmq CreateSimpleQueue -v cli-tests -t my-topic-with-retries -r 10000 20000`
+
+### Creating a fanout queue topology with 2 queues and 2 retries each.
+
+`./otcrabbitmq CreateMultipleQueues -v cli-tests -t my-topic-with-2-queues-and-2-retries-each -q my-queue-1 my-queue-2 -r 10000 20000`

--- a/Source/Otc.Messaging.RabbitMQ.Cli/RootCommandExtensions.cs
+++ b/Source/Otc.Messaging.RabbitMQ.Cli/RootCommandExtensions.cs
@@ -1,0 +1,13 @@
+﻿using System.CommandLine;
+
+namespace Otc.Messaging.RabbitMQ.Cli
+{
+    public static class RootCommandExtensions
+    {
+        public static void AddZeroOrOneOption<T>(this RootCommand cmd, Option<T> option)
+        {
+            option.Argument.Arity = ArgumentArity.ZeroOrOne;
+            cmd.AddGlobalOption(option);
+        }
+    }
+}

--- a/Source/Otc.Messaging.RabbitMQ.Cli/ServiceProvider.cs
+++ b/Source/Otc.Messaging.RabbitMQ.Cli/ServiceProvider.cs
@@ -1,0 +1,41 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Refit;
+using System;
+using System.Net.Http.Headers;
+using System.Text;
+
+namespace Otc.Messaging.RabbitMQ.Cli
+{
+    public static class ServiceProvider
+    {
+        private static IServiceProvider provider;
+
+        public static IServiceProvider GetInstance()
+        {
+            if (provider == null)
+            {
+                var services = new ServiceCollection();
+
+                var credentials = Convert.ToBase64String(
+                    Encoding.UTF8.GetBytes($"{Broker.User}:{Broker.Password}"));
+
+                services.AddRefitClient<IRabbitMQApi>()
+                    .ConfigureHttpClient(c =>
+                    {
+                        c.BaseAddress = new Uri(Broker.ApiBaseUrl);
+                        c.DefaultRequestHeaders.Authorization =
+                            new AuthenticationHeaderValue("Basic", credentials);
+                    });
+
+                services
+                    .AddLogging(b => b.AddConsole().SetMinimumLevel(LogLevel.Warning))
+                    .AddRabbitMQ(Broker.Configuration);
+
+                provider = services.BuildServiceProvider();
+            }
+
+            return provider;
+        }
+    }
+}

--- a/Source/Otc.Messaging.RabbitMQ.Cli/_assembly.cs
+++ b/Source/Otc.Messaging.RabbitMQ.Cli/_assembly.cs
@@ -1,0 +1,3 @@
+[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage(
+    "Maintainability", "S4457:Split this method into two, one handling " +
+    "parameters check and the other handling the asynchronous code.")]

--- a/Source/Otc.Messaging.RabbitMQ.PredefinedTopologies/RabbitMQConfigurationExtensions.cs
+++ b/Source/Otc.Messaging.RabbitMQ.PredefinedTopologies/RabbitMQConfigurationExtensions.cs
@@ -32,7 +32,7 @@ namespace Otc.Messaging.RabbitMQ.PredefinedTopologies
 
             var topologyFactory = new TTopologyFactory();
 
-            if(rabbitMQconfiguration.Topologies is null)
+            if (rabbitMQconfiguration.Topologies is null)
             {
                 rabbitMQconfiguration.Topologies = new Dictionary<string, Topology>();
             }

--- a/Source/Otc.Messaging.RabbitMQ.Tests/IntegrationTests.cs
+++ b/Source/Otc.Messaging.RabbitMQ.Tests/IntegrationTests.cs
@@ -259,6 +259,7 @@ namespace Otc.Messaging.RabbitMQ.Tests
         private readonly RabbitMQConfiguration configuration = new RabbitMQConfiguration
         {
             Hosts = new List<string> { "localhost" },
+            VirtualHost = "Tests",
             Port = 5672,
             User = "guest",
             Password = "guest",

--- a/Source/Otc.Messaging.RabbitMQ.Tests/appsettings.json
+++ b/Source/Otc.Messaging.RabbitMQ.Tests/appsettings.json
@@ -2,6 +2,7 @@
   "RabbitMQConfiguration": {
     "Hosts": [ "localhost" ],
     "Port": 5672,
+    "VirtualHost": "Tests",
     "User": "guest",
     "Password": "guest",
     "PerQueuePrefetchCount": 10,

--- a/Source/Otc.Messaging.RabbitMQ/Configurations/RabbitMQConfiguration.cs
+++ b/Source/Otc.Messaging.RabbitMQ/Configurations/RabbitMQConfiguration.cs
@@ -30,6 +30,11 @@ namespace Otc.Messaging.RabbitMQ.Configurations
         public int Port { set; get; } = AmqpTcpEndpoint.UseDefaultPort;
 
         /// <summary>
+        /// Virtual host to connect to.
+        /// </summary>
+        public string VirtualHost { set; get; } = ConnectionFactory.DefaultVHost;
+
+        /// <summary>
         /// User for connection.
         /// </summary>
         [Required]

--- a/Source/Otc.Messaging.RabbitMQ/RabbitMQMessaging.cs
+++ b/Source/Otc.Messaging.RabbitMQ/RabbitMQMessaging.cs
@@ -42,6 +42,7 @@ namespace Otc.Messaging.RabbitMQ
                     var factory = new ConnectionFactory()
                     {
                         Port = configuration.Port,
+                        VirtualHost = configuration.VirtualHost,
                         UserName = configuration.User,
                         Password = configuration.Password,
                         ClientProvidedName = configuration.ClientProvidedName,

--- a/Source/Otc.Messaging.sln
+++ b/Source/Otc.Messaging.sln
@@ -19,7 +19,9 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Otc.Messaging.Typed.Abstrac
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Otc.Messaging.Subscriber.HW", "Otc.Messaging.Subscriber.HW\Otc.Messaging.Subscriber.HW.csproj", "{A954B24E-982E-460A-8BE5-A1B559A968AD}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Otc.Messaging.RabbitMQ.PredefinedTopologies.Tests", "Otc.Messaging.RabbitMQ.PredefinedTopologies.Tests\Otc.Messaging.RabbitMQ.PredefinedTopologies.Tests.csproj", "{00BFE2F9-C469-4A4E-9B45-AF3BF28764EA}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Otc.Messaging.RabbitMQ.PredefinedTopologies.Tests", "Otc.Messaging.RabbitMQ.PredefinedTopologies.Tests\Otc.Messaging.RabbitMQ.PredefinedTopologies.Tests.csproj", "{00BFE2F9-C469-4A4E-9B45-AF3BF28764EA}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Otc.Messaging.RabbitMQ.Cli", "Otc.Messaging.RabbitMQ.Cli\Otc.Messaging.RabbitMQ.Cli.csproj", "{16B865A4-4552-472E-80B1-A678B849E7F9}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -63,6 +65,10 @@ Global
 		{00BFE2F9-C469-4A4E-9B45-AF3BF28764EA}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{00BFE2F9-C469-4A4E-9B45-AF3BF28764EA}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{00BFE2F9-C469-4A4E-9B45-AF3BF28764EA}.Release|Any CPU.Build.0 = Release|Any CPU
+		{16B865A4-4552-472E-80B1-A678B849E7F9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{16B865A4-4552-472E-80B1-A678B849E7F9}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{16B865A4-4552-472E-80B1-A678B849E7F9}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{16B865A4-4552-472E-80B1-A678B849E7F9}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
Implementing a simple command line utility allowing to apply predefined topologies found in Otc.Messaging.RabbitMQ.PredefinedTopologies.

Implementing CreateVirtualHost command that uses RabbitMQ API to create new virtual hosts.

Implementing new RabbitMQConfiguration property named VirtualHost. This will allow applications to specify which virtual host to connect to. Accommodating exchanges and queues in their own virtual host, organized by business context, will simplify visualization and maintenance in RabbitMQ Management UI. 
