### PR TITLE
Upgrade version to net core 3.1 and apoboot 4.0

### DIFF
--- a/Source/Otc.Messaging.Abstractions/Otc.Messaging.Abstractions.csproj
+++ b/Source/Otc.Messaging.Abstractions/Otc.Messaging.Abstractions.csproj
@@ -6,6 +6,7 @@
     <Copyright>Ole Consignado (c) 2020</Copyright>
     <VersionPrefix>1.0.0</VersionPrefix>
     <PackageProjectUrl>https://github.com/OleConsignado/otc-messaging/</PackageProjectUrl>
+    <Version>2.0.0</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/Source/Otc.Messaging.RabbitMQ.Cli/Otc.Messaging.RabbitMQ.Cli.csproj
+++ b/Source/Otc.Messaging.RabbitMQ.Cli/Otc.Messaging.RabbitMQ.Cli.csproj
@@ -4,6 +4,7 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <AssemblyName>otcrabbitmq</AssemblyName>
+    <Version>2.0.0</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Source/Otc.Messaging.RabbitMQ.PredefinedTopologies.Tests/Otc.Messaging.RabbitMQ.PredefinedTopologies.Tests.csproj
+++ b/Source/Otc.Messaging.RabbitMQ.PredefinedTopologies.Tests/Otc.Messaging.RabbitMQ.PredefinedTopologies.Tests.csproj
@@ -4,6 +4,8 @@
     <TargetFramework>netcoreapp3.1</TargetFramework>
 
     <IsPackable>false</IsPackable>
+
+    <Version>2.0.0</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Source/Otc.Messaging.RabbitMQ.PredefinedTopologies/Otc.Messaging.RabbitMQ.PredefinedTopologies.csproj
+++ b/Source/Otc.Messaging.RabbitMQ.PredefinedTopologies/Otc.Messaging.RabbitMQ.PredefinedTopologies.csproj
@@ -6,6 +6,7 @@
     <Copyright>Ole Consignado (c) 2020</Copyright>
     <VersionPrefix>1.0.0</VersionPrefix>
     <PackageProjectUrl>https://github.com/OleConsignado/otc-messaging/</PackageProjectUrl>
+    <Version>2.0.0</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/Source/Otc.Messaging.RabbitMQ.Tests/Otc.Messaging.RabbitMQ.Tests.csproj
+++ b/Source/Otc.Messaging.RabbitMQ.Tests/Otc.Messaging.RabbitMQ.Tests.csproj
@@ -1,9 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
 
     <IsPackable>false</IsPackable>
+
+    <Version>2.0.0</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Source/Otc.Messaging.RabbitMQ/Otc.Messaging.RabbitMQ.csproj
+++ b/Source/Otc.Messaging.RabbitMQ/Otc.Messaging.RabbitMQ.csproj
@@ -6,6 +6,7 @@
     <Copyright>Ole Consignado (c) 2020</Copyright>
     <VersionPrefix>1.0.0</VersionPrefix>
     <PackageProjectUrl>https://github.com/OleConsignado/otc-messaging/</PackageProjectUrl>
+    <Version>2.0.0</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/Source/Otc.Messaging.Subscriber.HW/Otc.Messaging.Subscriber.HW.csproj
+++ b/Source/Otc.Messaging.Subscriber.HW/Otc.Messaging.Subscriber.HW.csproj
@@ -1,11 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <Authors>Ole Consignado</Authors>
     <Copyright>Ole Consignado (c) 2020</Copyright>
     <VersionPrefix>1.0.0</VersionPrefix>
     <PackageProjectUrl>https://github.com/OleConsignado/otc-messaging/</PackageProjectUrl>
+    <Version>2.0.0</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
@@ -19,7 +20,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Otc.AspNetCore.ApiBoot" Version="3.2.0" />
+    <PackageReference Include="Otc.AspNetCore.ApiBoot" Version="4.0.0" />
     <PackageReference Include="Otc.HostedWorker" Version="1.2.0" />
   </ItemGroup>
 

--- a/Source/Otc.Messaging.Typed.Abstractions/Otc.Messaging.Typed.Abstractions.csproj
+++ b/Source/Otc.Messaging.Typed.Abstractions/Otc.Messaging.Typed.Abstractions.csproj
@@ -6,6 +6,7 @@
     <Copyright>Ole Consignado (c) 2020</Copyright>
     <VersionPrefix>1.0.0</VersionPrefix>
     <PackageProjectUrl>https://github.com/OleConsignado/otc-messaging/</PackageProjectUrl>
+    <Version>2.0.0</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/Source/Otc.Messaging.Typed.Tests/Otc.Messaging.Typed.Tests.csproj
+++ b/Source/Otc.Messaging.Typed.Tests/Otc.Messaging.Typed.Tests.csproj
@@ -1,9 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
 
     <IsPackable>false</IsPackable>
+
+    <Version>2.0.0</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Source/Otc.Messaging.Typed/Otc.Messaging.Typed.csproj
+++ b/Source/Otc.Messaging.Typed/Otc.Messaging.Typed.csproj
@@ -6,6 +6,7 @@
     <Copyright>Ole Consignado (c) 2020</Copyright>
     <VersionPrefix>1.0.0</VersionPrefix>
     <PackageProjectUrl>https://github.com/OleConsignado/otc-messaging/</PackageProjectUrl>
+    <Version>2.0.0</Version>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">


### PR DESCRIPTION
Atualização dos pacotes Otc.Messaging para .Net Core 3.1 devido a necessidade dessa versão para pipeline net do Santander.